### PR TITLE
removed showWhatsNewOnFirstInstall from whatsnewfeature class

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,7 +40,6 @@ class _MyHomePageState extends State<MyHomePage> {
     await const WhatsNewFeature().showWhatsNew(
       context,
       showWhatsNew: true,
-      showWhatsNewOnFirstInstall: true,
       features: [
         WhatsNewFeatureTile(
           icon: Icons.browse_gallery_rounded,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -356,7 +356,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1-dev.1"
+    version: "0.0.1-dev.2"
   win32:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.4+2
+version: 1.0.5+3
 
 environment:
   sdk: ">=2.16.2 <3.0.0"

--- a/lib/src/whats_new_feature.dart
+++ b/lib/src/whats_new_feature.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,7 +22,6 @@ class WhatsNewFeature {
     required bool showWhatsNew,
     Function()? navigatedToWhatsNewPage,
     required List<WhatsNewFeatureTile> features,
-    bool showWhatsNewOnFirstInstall = false,
     Color buttonColor = Colors.amber,
     Duration delay = const Duration(seconds: 1),
   }) async {
@@ -38,7 +39,7 @@ class WhatsNewFeature {
     /// do not show whats new feature page on the first install
     ///
     /// on the first install, [previousAppVersion] will always be empty
-    if (previousAppVersion.isEmpty && showWhatsNewOnFirstInstall == false) {
+    if (previousAppVersion.isEmpty) {
       await prefs.setString(installedAppVersionKey, currentAppVersion);
       return;
     }


### PR DESCRIPTION
in this PR, I have removed "showWhatsNewOnFirstInstall" variable from "WhatsNewFeature" class because this project's main purpose is to show the new feature page when ever the new release is build. No one wants to show the New Feature from their first install and the logic of "showWhatsNew" does not need to have "showWhatsNewOnFirstInstall" condition for setting version name data to shared preference.